### PR TITLE
add conda env, restart kernel and clear notebook

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -8,3 +8,4 @@ chapters:
 - file: notebooks
 - file: markdown-notebooks
 - file: markdown
+- file: new_velocity_data

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: mynewbook
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - geocube
+  - geopandas
+  - jupyter-book
+  - matplotlib-base
+  - rioxarray

--- a/new_velocity_data.ipynb
+++ b/new_velocity_data.ipynb
@@ -1,0 +1,336 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f41dc04e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import os\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import rioxarray as rxr\n",
+    "import matplotlib.pyplot as plt\n",
+    "from geocube.api.core import make_geocube"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8646018d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def components_to_speed(vx_path, vy_path):\n",
+    "    '''this function reads in x,y components of velocity, generates speed variable. return xarray\n",
+    "    dataset w/ x,y, speed variables. function will break if vx,vy objects don\"t have same x,y coords'''\n",
+    "    \n",
+    "    vy_ds = rxr.open_rasterio(vy_path, masked=False).squeeze()\n",
+    "    vx_ds = rxr.open_rasterio(vx_path, masked=False).squeeze()\n",
+    "    \n",
+    "    ds_gen = xr.Dataset()\n",
+    "    ds_gen['vx'] = vx_ds\n",
+    "    ds_gen['vy'] = vy_ds\n",
+    "    sp = np.sqrt((ds_gen['vx'].data**2) + ds_gen['vy'].data**2)\n",
+    "    ds_gen['sp'] = (['x','y'], sp.T)\n",
+    "    \n",
+    "    return ds_gen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cbbca63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n45_vy_path = '/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/gardner_data/N45_0240m_vy.tiff'\n",
+    "n45_vx_path = '/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/gardner_data/N45_0240m_vx.tiff'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb698670",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#make raster data w/ velocity component and speed variables for a single tiff file from Alex Gardner (single utm zone)\n",
+    "ds_45n = components_to_speed(n45_vx_path, n45_vy_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb739146",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#read in vector data \n",
+    "se_asia = gpd.read_file('/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/glacier_files/rgi_1km/se_asia_1km.shp')\n",
+    "#sw_asia = gpd.read_file('/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/rgi_1km/sw_asia_1km.shp')\n",
+    "#c_asia = gpd.read_file('/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/rgi_1km/central_asia_1km.shp') \n",
+    "\n",
+    "se_asia_path = '/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/rgi_1km/se_asia_1km.shp'\n",
+    "sw_asia_path = '/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/rgi_1km/sw_asia_1km.shp'\n",
+    "c_asia_path = '/Users/emmamarshall/Desktop/phd_research/nisar_prepwork/rgi_1km/central_asia_1km.shp'\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b92444b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "se_asia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05c5dd6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#take first 100 glaciers\n",
+    "se_asia_100 = se_asia.iloc[:100,:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed48cad9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rasterize_vector(gpdf, utm_code, raster_obj): \n",
+    "    \n",
+    "    #read in gpdf from shp file\n",
+    "    #gpdf = gpd.read_file(vector_path)\n",
+    "    #project to local utm\n",
+    "    gpdf_utm = gpdf.to_crs(f'EPSG:{utm_code}')\n",
+    "    #use index as a unique key for each glacier\n",
+    "    gpdf_utm['Integer_ID'] = gpdf_utm.index.astype(int)\n",
+    "    #print(gpdf_utm['Integer_ID'])\n",
+    "    \n",
+    "    #rasterize glacier vector by unique id \n",
+    "\n",
+    "    out_grid = make_geocube(\n",
+    "            vector_data = gpdf_utm,\n",
+    "            measurements = ['Integer_ID'],\n",
+    "            like = raster_obj['sp'] #need to specify a var here, not sure best way to do that\n",
+    "            )\n",
+    "    \n",
+    "    #now merge the rasterized vector and the original raster togehter into a geocube\n",
+    "    out_grid['speed'] = (raster_obj.dims, raster_obj.sp.values, raster_obj.attrs, raster_obj.encoding)\n",
+    "    \n",
+    "    #now, get velocity statistics of each 'region' (integer) using the mask\n",
+    "    #grouped_ID = out_grid.drop('spatial_ref').groupby(out_grid.Integer_ID)\n",
+    "\n",
+    "    #compute zonal stats groupedd by ID\n",
+    "    #grid_mean_sp = grouped_ID.mean().rename({'speed': 'speed_mean'})\n",
+    "    #grid_min_sp = grouped_ID.min().rename({'speed': 'speed_min'})\n",
+    "    #grid_max_sp = grouped_ID.max().rename({'speed': 'speed_max'})\n",
+    "    #grid_std_sp = grouped_ID.max().rename({'speed': 'speed_std'})\n",
+    "    \n",
+    "    #merge each zonal stat xr obj into a single xr obj, convert to pandas df\n",
+    "    #zonal_stats = xr.merge([grid_mean_sp, grid_min_sp, grid_max_sp, grid_std_sp]).to_dataframe()\n",
+    "    #zonal_stats = zonal_stats.reset_index()\n",
+    "    \n",
+    "   # return zonal_stats\n",
+    "    return out_grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2f03fe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasterize_vector_seasia_100 = rasterize_vector(se_asia_100, 32645, ds_45n)\n",
+    "rasterize_vector_seasia_100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82ea6d17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasterize_vector_seasia_100.plot.scatter(x='Integer_ID', y='speed',c='darkblue')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0541f923",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#project to utm\n",
+    "se_asia_utm = se_asia.to_crs('EPSG:32645')\n",
+    "#make a col in df that is a unique integer ID (from index) for each glacier\n",
+    "se_asia_utm['Integer_ID'] = se_asia_utm.index.astype(int)\n",
+    "#double checking that all glaciers are assigned an ID\n",
+    "se_asia_utm.plot.scatter(x='Integer_ID', y='Area')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f32ed29b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#rasterize glacier vector by unique id \n",
+    "#\n",
+    "out_grid_se_asia = make_geocube(\n",
+    "            vector_data = se_asia_utm,\n",
+    "            measurements = ['Integer_ID'],\n",
+    "            like = ds_45n['sp']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80e2be7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#now merge the rasterized vector and the original raster togehter into a geocube\n",
+    "out_grid_se_asia['speed'] = (ds_45n.dims, ds_45n.sp.values, ds_45n.attrs, ds_45n.encoding)\n",
+    "out_grid_se_asia"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4bcb3fd3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#trying to figure out why 1300 glaciers or so get dropped\n",
+    "print(len(out_grid_se_asia.Integer_ID))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1cc9d337",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#now, get velocity statistics of each 'region' (integer) using the mask\n",
+    "grouped_ID = out_grid_se_asia.drop('spatial_ref').groupby(out_grid_se_asia.Integer_ID)\n",
+    "grouped_ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28b1b6a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid_mean_sp = grouped_ID.mean().rename({'speed': 'speed_mean'})\n",
+    "grid_median_sp = grouped_ID.median().rename({'speed': 'speed_median'})\n",
+    "grid_min_sp = grouped_ID.min().rename({'speed': 'speed_min'})\n",
+    "grid_max_sp = grouped_ID.max().rename({'speed': 'speed_max'})\n",
+    "grid_std_sp = grouped_ID.max().rename({'speed': 'speed_std'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63cbca70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zonal_stats = xr.merge([grid_mean_sp, grid_median_sp, grid_min_sp, grid_max_sp, grid_std_sp]).to_dataframe()\n",
+    "zonal_stats = zonal_stats.reset_index()\n",
+    "zonal_stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b06e23d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#now, trying to merge zonal stats df back with original glacier df on integer_ID col\n",
+    "se_asia_glacier_data = se_asia_utm.merge(zonal_stats, on='Integer_ID')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3158e65b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zonal_stats['speed_mean']\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "se_asia_glacier_data.plot.scatter(x='Integer_ID',y = 'speed_mean', c = 'darkblue', ax=ax)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eabab934",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zonal_stats['speed_mean'].min()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d3b976a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "se_asia_glacier_data.plot(column='speed_mean', legend=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d0187d9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,9 @@
+# Jupyterbook
+
+to build:
+```
+cd mynewbook
+conda env create
+conda activate mynewbook
+jupyter-book build .
+```


### PR DESCRIPTION
Fixes `jupyter_client.kernelspec.NoSuchKernel: No such kernel named conda-env-geopandas_work-py` by adding a conda environment and clearing the new_velocity_data.ipynb notebook output and metadata.

jupyterbook by default expects notebooks to have a conda environment / kernel that is present. For now it's easiest to have everything with a single default kernel name (python3), which is the case if you go to 'Kernel' -> 'Restart and Clear' output.

You can check the kernel name for a notebook with `tail -n 25 new_velocity_data.ipynb` and it should show:
```
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3 (ipykernel)",
   "language": "python",
   "name": "python3"
  },
```